### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -1,11 +1,6 @@
 name: Containerize and Push to Container Registry
 
-# Containerizes and pushes a build of Chariott Intent Brokering to a container registry.
-#
-# To use this in your own clone of this repo, you need to configure three Github Action secrets:
-# 1. CONTAINER_REGISTRY_ENDPOINT: The DNS endpoint of your container registry (eg. sdv.azurecr.io)
-# 2. CONTAINER_REGISTRY_USERNAME: A user for your container registry that has push permissions.
-# 3. CONTAINER_REGISTRY_PASSWORD: The auth password for your container registry user
+# Containerizes and pushes a build of Chariott Intent Brokering to GHCR.IO.
 
 on:
   push:
@@ -27,6 +22,7 @@ concurrency:
 
 env:
   IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
 
 jobs:
   build-and-push-image:
@@ -34,6 +30,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -52,15 +50,15 @@ jobs:
       - name: Login to the Container registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}
-          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
-          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata and create {branch}-{sha} tag
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ secrets.CONTAINER_REGISTRY_ENDPOINT }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
 
@@ -73,3 +71,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: RUST_VERSION=${{ steps.rust_version.outputs.RUST_VERSION }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.build-and-push-image.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -85,7 +85,7 @@ jobs:
           docker logs intent_brokering
 
       - name: Archive Intent Brokering log output
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Intent Brokering E2E log
           path: intent_brokering.log

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -75,7 +75,7 @@ jobs:
           version: '0.21.0'
           args: '--workspace --ignore-tests --skip-clean --exclude-files spikes/* --exclude-files examples/* --exclude-files tests/*'
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml


### PR DESCRIPTION
Updates:

- updated actions/upload-artifact@v2 to actions/upload-artifact@v4 per [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
- updated "Containerizes and pushes a build of Chariott Intent Brokering" action to push to GHCR.IO instead of a private container registry
- added build provenance attestation for the Intent Brokering container images